### PR TITLE
fix pocha loadmodule error; exclude test directory

### DIFF
--- a/pocha/discover.py
+++ b/pocha/discover.py
@@ -5,6 +5,7 @@ testing hierarchy as represented by the underlying tests.
 """
 import os
 import imp
+import sys
 
 from collections import OrderedDict
 
@@ -77,7 +78,43 @@ def search(path, expression):
 
     # load each module and then we'll have a complete list of the tests
     # to run
+    def get_module_package_root_path_and_module_name(module_full_path):
+        module_full_path = module_full_path.replace('/', os.path.sep).replace('\\', os.path.sep)
+        path_list = module_full_path.split(os.path.sep)
+        if path_list[-1].endswith('.py'):
+            path_list[-1] = path_list[-1][:-3]
+        module_name_list = []
+        module_dir = os.path.sep.join(path_list[:-1])
+        while True:
+            if len(path_list) > 0:
+                module_name_list.insert(0, path_list.pop())
+                package_init_file_path = os.path.sep.join(path_list + ['__init__.py'])
+                if os.path.isfile(package_init_file_path):
+                    module_dir = os.path.sep.join(path_list[:-1])
+                else:
+                    break
+        # print '==: ', module_dir, module_name_list
+        return module_dir, '.'.join(module_name_list)
+
     for module in modules:
-        imp.load_source('foo', module)
-    
+        cur_dir = os.getcwdu()
+        module = module.replace('/', os.path.sep).replace('\\', os.path.sep)
+        abs_path = os.path.abspath(os.path.join(cur_dir, module)).replace('/', os.path.sep).replace('\\', os.path.sep)
+        if not module.endswith('.py'):
+            continue
+        # print get_module_package_root_path_and_module_name(abs_path)
+        module_dir, module_name = get_module_package_root_path_and_module_name(abs_path)
+        try:
+            if module in sys.modules:
+                del sys.modules[module] 
+            sys.path.insert(0, module_dir)
+            __import__(module_name)
+        except ImportError as e:
+            raise e
+        except Exception as e:
+            raise e
+        finally:
+            sys.path.remove(module_dir)
+
+    # print common.TESTS
     return filter_tests(common.TESTS, expression)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     test_suite='test',
     keywords=[''],
     py_modules=['pocha'],
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['test']),
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
## 1
I wrote some demos at https://github.com/letiantian/pocha-demos. However pocha can not run exactly, and raise errors:
```
$ pocha demo01/add_test.py 
...
  File "demo01/add_test.py", line 4, in <module>
    import add
ImportError: No module named add
```
Thus, I fixed it with `__import__`.

## 2
The examples in [test](https://github.com/rlgomes/pocha/tree/master/test) should not run exactly.  But in fact, they run exactly. 
I found the reason is that the [test](https://github.com/rlgomes/pocha/tree/master/test) directory  was installed by pip. 