### PR TITLE
fixed a few more import issues

### DIFF
--- a/pocha/discover.py
+++ b/pocha/discover.py
@@ -1,6 +1,6 @@
 """
-pocha test discovery module responsible for creating a dictionary containing the
-testing hierarchy as represented by the underlying tests.
+pocha test discovery module responsible for creating a dictionary containing
+the testing hierarchy as represented by the underlying tests.
 
 """
 import os
@@ -80,10 +80,12 @@ def search(path, expression):
     # to run
     for module in modules:
         module_path = os.path.dirname(module)
+        sys.path.insert(0, '.')
         sys.path.insert(0, module_path)
         try:
             imp.load_source('foo', module)
         finally:
+            sys.path.remove('.')
             sys.path.remove(module_path)
 
     return filter_tests(common.TESTS, expression)

--- a/test/input/describe_with_local_module_from_import.py
+++ b/test/input/describe_with_local_module_from_import.py
@@ -1,10 +1,10 @@
 from pocha import describe, it
 
-import util
+from test.input import util
 
 @describe('top level describe')
 def describe1():
 
-    @it('can call out to a local module import')
+    @it('can call out to a local module from import')
     def _():
         assert util.add(1, 1) == 2

--- a/test/input/describe_with_local_module_relative_from_import.py
+++ b/test/input/describe_with_local_module_relative_from_import.py
@@ -1,10 +1,11 @@
 from pocha import describe, it
 
-import util
+from ..input import util
+
 
 @describe('top level describe')
 def describe1():
 
-    @it('can call out to a local module import')
+    @it('can call out to a local module from import')
     def _():
         assert util.add(1, 1) == 2

--- a/test/test_describe.py
+++ b/test/test_describe.py
@@ -21,7 +21,22 @@ def pocha_cli():
             stdout = cmd.stdout.decode('utf-8')
             expect(stdout).to.match(u'''
   top level describe
-    ✓ can call out to a local module
+    ✓ can call out to a local module import
+
+  1 passing \(.*ms\)
+
+''')
+
+    @it('can run test with local module from X import Y')
+    def local_module_import():
+            cmd = sh.python('pocha/cli.py',
+                            'test/input/describe_with_local_module_from_import.py',
+                            _ok_code=[0],
+                            _tty_out=False)
+            stdout = cmd.stdout.decode('utf-8')
+            expect(stdout).to.match(u'''
+  top level describe
+    ✓ can call out to a local module from import
 
   1 passing \(.*ms\)
 


### PR DESCRIPTION
@letiantian these will fix your issues except for demo06 which is really just the way python works when it comes to relative imports where you can't just use them in the middle of a non package scenario (ie installed on the system and not attempting to relatively import from code at a specific path). You can see that even executing it as a python script hits the same issue:

```bash 
rlgomes@t460s> python demo01/test_add.py               
2017-08-28 08:19:27 $?=0 pwd=/home/rlgomes/workspace/python/pocha/pocha-demos venv=env branch=master duration=.060s                                                      
rlgomes@t460s> python demo06/test/test_calculate_add.py
Traceback (most recent call last):
  File "demo06/test/test_calculate_add.py", line 5, in <module>
    from .. import calculate 
ValueError: Attempted relative import in non-package
2017-08-28 08:19:29 $?=1 pwd=/home/rlgomes/workspace/python/pocha/pocha-demos venv=env branch=master duration=.058s     
```

You can see that demo01 is fine but demo06 is invalid python. More details here:

https://stackoverflow.com/questions/11536764/how-to-fix-attempted-relative-import-in-non-package-even-with-init-py