### PR TITLE
pocha can now run a test living inside a directory with the same name

### DIFF
--- a/pocha/discover.py
+++ b/pocha/discover.py
@@ -25,6 +25,9 @@ def __load_modules(path):
             return modules
 
         for filename in os.listdir(path):
+            if filename == '__init__.py':
+                continue
+
             modules += __load_modules(os.path.join(path, filename))
 
     return modules
@@ -87,8 +90,8 @@ def search(path, expression):
             sys.path.insert(0, '..')
             module = module.replace('../', '')
 
-        sys.path.insert(0, '.')
         sys.path.insert(0, module_path)
+        sys.path.insert(0, '.')
         try:
             name = module.replace('/', '.')
             if '.py' in name:

--- a/test/input/foo/foo.py
+++ b/test/input/foo/foo.py
@@ -1,0 +1,8 @@
+from pocha import describe, it
+
+@describe('foo suite')
+def describe1():
+
+    @it('foo test')
+    def _():
+        pass

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+import os
+
 import sh
 
 from robber import expect
@@ -71,5 +73,28 @@ Options:
   2 passing (0ms)
 
 ''')
+        stderr = cmd.stderr.decode('utf-8')
+        expect(stderr).to.eq('')
+
+    @it('can run a test suite with same name as test directory')
+    def _():
+        cwd = os.getcwd()
+        try:
+            os.chdir('test/input')
+            cmd = sh.python('../../pocha/cli.py',
+                            'foo/foo.py',
+                            _ok_code=[0],
+                            _tty_out=False)
+            stdout = cmd.stdout.decode('utf-8')
+            expect(stdout).to.eq(u'''
+  foo suite
+    ✓ foo test
+
+  1 passing (0ms)
+
+''')
+        finally:
+            os.chdir(cwd)
+
         stderr = cmd.stderr.decode('utf-8')
         expect(stderr).to.eq('')


### PR DESCRIPTION
fixes #16

* just an ordering issue with the way we're mucking around with the
`sys.path` and added a test that was failing before I got this working